### PR TITLE
Fix a MiKTeX bug, when checking the pdflatex executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ A few things to keep in mind:
 - **pre-release**
   - Bug fixes:
     - Fix bug in header include function.
+    - Fix a bug when using MikTeX.
   - Other:
     - Deactivate possible externalization in TikZ constructs.
 - **v0.0.7**

--- a/l2a/src/l2a_global/l2a_global.cpp
+++ b/l2a/src/l2a_global/l2a_global.cpp
@@ -364,7 +364,7 @@ bool L2A::GLOBAL::Global::CheckLatexCommand(const ai::FilePath& path_latex) cons
         // The directory does not exist and is not empty -> this will not work.
         return false;
 
-    command_latex += " -v";
+    command_latex += " -version";
     ai::UnicodeString command_output;
     try
     {


### PR DESCRIPTION
The LaTeX check now also works with MiKTeX