### PR TITLE
Warning for unicode characters in path

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ After the document is loaded, LaTeX2AI automatically restores the missing items.
 Redoing an item by double clicking on it will not trigger an individual undo entry.
 The changes made in the redo process will be appended to the last undo entry.
 
+## Non ASCII characters in the document name or path
+LaTeX2AI does not work if there are non ASCII characters in the document name or full document path.
+
+
 # License & How to cite
 LaTeX2AI is under the MIT license, see [./LICENSE](LICENSE).
 If you use LaTeX2AI to create figures for your work, please acknowledge it with a link to the GitHub repository.
@@ -156,6 +160,9 @@ A few things to keep in mind:
 
 
 # Changelog
+- **pre-release**
+  - Other:
+    - Add warning that LaTeX2AI is not compatible with non ASCII characters in the document path.
 - **v0.0.9**
   - Features:
     - Add storage of labels inside Illustrator.

--- a/l2a/src/l2a_error/l2a_error.h
+++ b/l2a/src/l2a_error/l2a_error.h
@@ -109,4 +109,9 @@ namespace L2A
 #define l2a_check_ai_error(err) \
     if (err) l2a_error(L2A::ERR::AIErrorCodeToErrorString(err))
 
+/**
+ * \brief Throw a warning.
+ */
+#define l2a_warning(warning) throw L2A::ERR::Warning(warning);
+
 #endif  // L2A_ERROR_H_

--- a/l2a/src/utility/file_system.cpp
+++ b/l2a/src/utility/file_system.cpp
@@ -241,8 +241,20 @@ ai::FilePath L2A::UTIL::GetDocumentPath(bool fail_if_not_saved)
 
     // Check if the path is a file.
     if (!IsFile(path) && fail_if_not_saved)
-        throw L2A::ERR::Warning(ai::UnicodeString(
+    {
+        l2a_warning(ai::UnicodeString(
             "The document is not saved! Almost all functionality of LaTeX2AI requires the document to be saved."));
+    }
+    else
+    {
+        // Check if non ASCII characters appear in the path.
+        ai::UnicodeString unicode_path = path.GetFullPath();
+        ai::UnicodeString utf8_path(path.GetFullPath().as_UTF8());
+        if (unicode_path != utf8_path)
+            l2a_warning(
+                ai::UnicodeString("The document path contains non ASCII characters. LaTeX2AI is only working if there "
+                                  "are non ASCII characters in the document name / path."));
+    }
 
     return path;
 }


### PR DESCRIPTION
Add a warning it the document file path or name contain non ASCII characters.