### PR TITLE
Fix deselect bug

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+-   **pre-release**
+    -   Bug fixes:
+        -   Fix bug that caused Illustrator to crash when deselecting all active LaTeX2AI elements [#189](https://github.com/isteinbrecher/latex2ai/issues/189).
 -   **v1.0.1**
     -   Bug fixes:
         -   Fix bug that caused problems when using items that were created using a deprecated hash algorithm.

--- a/src/l2a_annotator.cpp
+++ b/src/l2a_annotator.cpp
@@ -190,10 +190,10 @@ void L2A::Annotator::Draw(AIAnnotatorMessage* message) const
 /**
  *
  */
-void L2A::Annotator::InvalAnnotation(AIAnnotatorMessage* message) const
+void L2A::Annotator::InvalAnnotation(const AIRealRect& artwork_bounds) const
 {
     // Get the rectangle to invalidate.
-    AIRect inval_rect = L2A::AI::ArtworkBoundsToViewBounds(*message->invalidationRects);
+    AIRect inval_rect = L2A::AI::ArtworkBoundsToViewBounds(artwork_bounds);
 
     // Invalidate the rect bounds so it is redrawn.
     AIErr result = sAIAnnotator->InvalAnnotationRect(nullptr, &inval_rect);
@@ -211,7 +211,5 @@ void L2A::Annotator::InvalAnnotation() const
     l2a_check_ai_error(result);
 
     // Invalidate the rect bounds so it is redrawn.
-    AIRect inval_rect = L2A::AI::ArtworkBoundsToViewBounds(view_bounds);
-    result = sAIAnnotator->InvalAnnotationRect(nullptr, &inval_rect);
-    l2a_check_ai_error(result);
+    InvalAnnotation(view_bounds);
 }

--- a/src/l2a_annotator.h
+++ b/src/l2a_annotator.h
@@ -104,7 +104,7 @@ namespace L2A
         /**
          * \brief Invalidate the annotation.
          */
-        void InvalAnnotation(AIAnnotatorMessage* message) const;
+        void InvalAnnotation(const AIRealRect& artwork_bounds) const;
 
         /**
          * \brief Invalidate the entire document view bounds.

--- a/src/l2a_plugin.cpp
+++ b/src/l2a_plugin.cpp
@@ -157,14 +157,35 @@ ASErr L2APlugin::Message(char* caller, char* selector, void* message)
         {
             if (strcmp(caller, kCallerAIAnnotation) == 0)
             {
-                if (strcmp(selector, kSelectorAIDrawAnnotation) == 0)
-                    // Draw the l2a annotator.
-                    annotator_->Draw((AIAnnotatorMessage*)message);
-                else if (strcmp(selector, kSelectorAIInvalAnnotation) == 0)
-                    // Invalidate the annotator.
-                    // TODO: maybe this function call can be removed. Check if it is called at all / what the given
-                    // invalidate box actually is.
-                    annotator_->InvalAnnotation((AIAnnotatorMessage*)message);
+                auto* annotator_message = (AIAnnotatorMessage*)message;
+                if (annotator_message == nullptr)
+                {
+                    // In case the annotator message pointer is null, we don't do anything here.
+                }
+                else
+                {
+                    if (strcmp(selector, kSelectorAIDrawAnnotation) == 0)
+                        // Draw the l2a annotator.
+                        annotator_->Draw(annotator_message);
+                    else if (strcmp(selector, kSelectorAIInvalAnnotation) == 0)
+                    {
+                        // Invalidate the annotator.
+                        // TODO: maybe this function call can be removed. Check if it is called at all / what the given
+                        // invalidate box actually is.
+
+                        // In some calls, the pointer to the invalidation rectangle is null, in these cases we
+                        // invalidate the whole document view.
+                        auto* artwork_bounds = annotator_message->invalidationRects;
+                        if (artwork_bounds == nullptr)
+                        {
+                            annotator_->InvalAnnotation();
+                        }
+                        else
+                        {
+                            annotator_->InvalAnnotation(*artwork_bounds);
+                        }
+                    }
+                }
             }
         }
         else


### PR DESCRIPTION
Fix a bug that caused Illustrator to crash, if the LaTeX2AI create/edit tool is activated and all items are deselected.