### PR TITLE
Fix bug with invalid pointers in annotator

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,9 +2,10 @@
 
 # Main developer
 
-Ivo Steinbrecher (isteinbrecher)
+Ivo Steinbrecher (@isteinbrecher)
 
 # Contributors (in chronological order of their first contribution)
 
-Nikita Rushmanov (nikita240)
-Da Zhi (dzhi1993)
+Nikita Rushmanov (@nikita240)
+Da Zhi (@dzhi1993)
+@MGG1996

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+-   **pre-release**
+    -   Bug fixes:
+        -   Fix bug that could arise when the item vector inside the annotator contained items with non-valid pointers
 -   **v1.0.2**
     -   Bug fixes:
         -   Fix bug that caused Illustrator to crash when deselecting all active LaTeX2AI elements [#189](https://github.com/isteinbrecher/latex2ai/issues/189).

--- a/src/l2a_plugin.cpp
+++ b/src/l2a_plugin.cpp
@@ -102,10 +102,8 @@ ASErr L2APlugin::Notify(AINotifierMessage* message)
         {
             // Selection of art items changed in the document.
 
-            // Invalidate the entire document view bounds.
+            // Update the annotator view bounds and the internal item vector.
             annotator_->InvalAnnotation();
-
-            // If the annotator is active, update the item vector.
             annotator_->ArtSelectionChanged();
 
             // Check if there is a single isolated l2a item.
@@ -126,6 +124,10 @@ ASErr L2APlugin::Notify(AINotifierMessage* message)
             {
                 L2A::AI::UndoActivate();
                 L2A::CheckItemDataStructure();
+
+                // Update the annotator view bounds and the internal item vector.
+                annotator_->InvalAnnotation();
+                annotator_->ArtSelectionChanged();
             }
         }
         else if (message->notifier == notify_CSXS_plugplug_setup_complete_)

--- a/src/utils/l2a_ai_functions.cpp
+++ b/src/utils/l2a_ai_functions.cpp
@@ -991,6 +991,11 @@ void L2A::AI::GetIsHiddenLocked(const AIArtHandle& art_item, bool& is_hidden, bo
 /**
  *
  */
+bool L2A::AI::IsValidArt(const AIArtHandle& art_item) { return sAIArt->ValidArt(art_item, true); }
+
+/**
+ *
+ */
 bool L2A::AI::GetLockedInsertionPoint()
 {
     AIArtHandle art;

--- a/src/utils/l2a_ai_functions.h
+++ b/src/utils/l2a_ai_functions.h
@@ -166,15 +166,15 @@ namespace L2A
 
         /**
          * \brief Get art handles in the document.
-         * @param items(out) Vector that will be cleared and filled up with the found items.
-         * @param selected(in) Which selection state should be searched.
-         * @param type(in) Type of the items to search.
+         * @param items (out) Vector that will be cleared and filled up with the found items.
+         * @param selected (in) Which selection state should be searched.
+         * @param type (in) Type of the items to search.
          */
         void GetItems(std::vector<AIArtHandle>& items, SelectionState selected, ai::int16 type = kAnyArt);
 
         /** Gets all placed items that are L2A items in the current document.
-         * @param l2a_items(out) vector that returns the art handles that match the description.
-         * @param selected(in) Type of selected items to search.
+         * @param l2a_items (out) vector that returns the art handles that match the description.
+         * @param selected (in) Type of selected items to search.
          */
         void GetDocumentItems(std::vector<AIArtHandle>& l2a_items, SelectionState selected);
 
@@ -279,37 +279,43 @@ namespace L2A
 
         /**
          * \brief Get the points on a path art item.
-         * @params path_item(in) Path item to get the points from.
-         * @params points(out) Vector with the path points.
-         * @params append_to_vector(in) If the points should be appended to vector, of if vector shoyuld be cleared
+         * @params path_item (in) Path item to get the points from.
+         * @params points (out) Vector with the path points.
+         * @params append_to_vector (in) If the points should be appended to vector, of if vector shoyuld be cleared
          * first.
          */
         void GetPathPoints(AIArtHandle& path_item, std::vector<AIRealPoint>& points, bool append_to_vector = false);
 
         /**
          * \brief Get the parent item of the art item.
-         * @params art_item(in) Art item.
-         * @params parent(out) Parent art item.
+         * @params art_item (in) Art item.
+         * @params parent (out) Parent art item.
          * @return True if parent exists.
          */
         bool GetArtParent(const AIArtHandle& art_item, AIArtHandle& parent);
 
         /**
          * \brief Get all parents of an art item.
-         * @params art_item(in) Art item.
-         * @params parents(out) Parents of the art item. The first item in the vector will be top parent, i.e. the main
+         * @params art_item (in) Art item.
+         * @params parents (out) Parents of the art item. The first item in the vector will be top parent, i.e. the main
          * layer.
          */
         void GetArtParents(const AIArtHandle& art_item, std::vector<AIArtHandle>& parents);
 
         /**
-         * \brief Check if a item is locked and or hidden in AI, including the parent locked / hidden settings.
-         * @params art_item(in) Art item.
-         * @params is_hidden(out) If the item or any of the parents are hidden.
-         * @params is_locked(out) If the item or any of the parents are locked.
+         * \brief Check if an item is locked and or hidden in AI, including the parent locked / hidden settings.
+         * @params art_item (in) Art item.
+         * @params is_hidden (out) If the item or any of the parents are hidden.
+         * @params is_locked (out) If the item or any of the parents are locked.
          * layer.
          */
         void GetIsHiddenLocked(const AIArtHandle& art_item, bool& is_hidden, bool& is_locked);
+
+        /**
+         * \brief Check if an item (internally that is a pointer) is valid.
+         * @params art_item (in) Art item.
+         */
+        bool IsValidArt(const AIArtHandle& art_item);
 
         /**
          * \brief Check if the current insertion point is locked and or hidden, i.e. no item can be created.


### PR DESCRIPTION
Closes #169

This PR fixes a bug that can occur, where the art item pointers in the annotator object are invalid. See #169.